### PR TITLE
Test /search and /reverse routes, then functions inclued in lib/search

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -34,7 +34,7 @@ export function formatParams({queries, operation}) {
   return params
 }
 
-function createFeatureCollection({params, operation, results}) {
+export function createFeatureCollection({params, operation, results}) {
   const fc = {
     type: 'FeatureCollection',
     version: 'draft',

--- a/lib/search.js
+++ b/lib/search.js
@@ -2,7 +2,7 @@ import process from 'node:process'
 
 const ADDOK_FILTERS = process.env.ADDOK_FILTERS ? process.env.ADDOK_FILTERS.split(',') : []
 
-function ensureSingleValue(value) {
+export function ensureSingleValue(value) {
   if (Array.isArray(value)) {
     return value[value.length - 1]
   }

--- a/lib/search.js
+++ b/lib/search.js
@@ -10,7 +10,7 @@ export function ensureSingleValue(value) {
   return value
 }
 
-function formatParams({queries, operation}) {
+export function formatParams({queries, operation}) {
   const params = {
     lon: queries.lon ? Number.parseFloat(ensureSingleValue(queries.lon)) : undefined,
     lat: queries.lat ? Number.parseFloat(ensureSingleValue(queries.lat)) : undefined,

--- a/test/routes.js
+++ b/test/routes.js
@@ -1,6 +1,7 @@
 import test from 'ava'
 import request from 'supertest'
 import express from 'express'
+import createError from 'http-errors'
 import createRouter from '../lib/routes.js'
 
 test('routes / search / results', async t => {
@@ -46,4 +47,76 @@ test('routes / search / no results', async t => {
     limit: 5,
     version: 'draft'
   })
+})
+
+test('routes / reverse / results', async t => {
+  const cluster = {
+    reverse() {
+      return [{id: 'foo'}]
+    }
+  }
+
+  const app = express()
+  app.use('/', createRouter(cluster))
+
+  const response = await request(app).get('/reverse').expect(200)
+  t.deepEqual(response.body, {
+    type: 'FeatureCollection',
+    attribution: 'BAN',
+    features: [
+      {id: 'foo'}
+    ],
+    licence: 'ETALAB-2.0',
+    limit: 1,
+    version: 'draft'
+  })
+})
+
+test('routes / reverse / no results', async t => {
+  const cluster = {
+    reverse() {
+      return []
+    }
+  }
+
+  const app = express()
+  app.use('/', createRouter(cluster))
+
+  const response = await request(app).get('/reverse').expect(200)
+  t.deepEqual(response.body, {
+    type: 'FeatureCollection',
+    attribution: 'BAN',
+    features: [],
+    licence: 'ETALAB-2.0',
+    limit: 1,
+    version: 'draft'
+  })
+})
+
+test('routes / search / invalid parameter', async t => {
+  const cluster = {
+    geocode() {
+      throw createError(400, 'Invalid search parameter')
+    }
+  }
+
+  const app = express()
+  app.use('/', createRouter(cluster))
+
+  const {body} = await request(app).get('/search').expect(400)
+  t.is(body.message, 'Invalid search parameter')
+})
+
+test('routes / reverse / invalid parameter', async t => {
+  const cluster = {
+    reverse() {
+      throw createError(400, 'Invalid reverse parameter')
+    }
+  }
+
+  const app = express()
+  app.use('/', createRouter(cluster))
+
+  const {body} = await request(app).get('/reverse').expect(400)
+  t.is(body.message, 'Invalid reverse parameter')
 })

--- a/test/routes.js
+++ b/test/routes.js
@@ -1,0 +1,49 @@
+import test from 'ava'
+import request from 'supertest'
+import express from 'express'
+import createRouter from '../lib/routes.js'
+
+test('routes / search / results', async t => {
+  const cluster = {
+    geocode() {
+      return [{id: 'foo'}, {id: 'bar'}]
+    }
+  }
+
+  const app = express()
+  app.use('/', createRouter(cluster))
+
+  const response = await request(app).get('/search').expect(200)
+  t.deepEqual(response.body, {
+    type: 'FeatureCollection',
+    attribution: 'BAN',
+    features: [
+      {id: 'foo'},
+      {id: 'bar'}
+    ],
+    licence: 'ETALAB-2.0',
+    limit: 5,
+    version: 'draft'
+  })
+})
+
+test('routes / search / no results', async t => {
+  const cluster = {
+    geocode() {
+      return []
+    }
+  }
+
+  const app = express()
+  app.use('/', createRouter(cluster))
+
+  const response = await request(app).get('/search').expect(200)
+  t.deepEqual(response.body, {
+    type: 'FeatureCollection',
+    attribution: 'BAN',
+    features: [],
+    licence: 'ETALAB-2.0',
+    limit: 5,
+    version: 'draft'
+  })
+})

--- a/test/search.js
+++ b/test/search.js
@@ -1,0 +1,17 @@
+import test from 'ava'
+
+import {ensureSingleValue} from '../lib/search.js'
+
+test('ensure single value / with array', t => {
+  const value = ['first', 'second', 'last']
+  t.is(ensureSingleValue(value), 'last')
+})
+
+test('ensure single value / with string', t => {
+  t.is(ensureSingleValue('value'), 'value')
+})
+
+test('ensure single value / with undefined', t => {
+  t.is(ensureSingleValue(undefined), undefined)
+})
+

--- a/test/search.js
+++ b/test/search.js
@@ -4,20 +4,20 @@ import test from 'ava'
 
 import {ensureSingleValue, formatParams} from '../lib/search.js'
 
-test('ensure single value / with array', t => {
+test('ensureSingleValue / with array', t => {
   const value = ['first', 'second', 'last']
   t.is(ensureSingleValue(value), 'last')
 })
 
-test('ensure single value / with string', t => {
+test('ensureSingleValue / with string', t => {
   t.is(ensureSingleValue('value'), 'value')
 })
 
-test('ensure single value / with undefined', t => {
+test('ensureSingleValue / with undefined', t => {
   t.is(ensureSingleValue(undefined), undefined)
 })
 
-test('Format parameters / operation geocode', t => {
+test('formatParams / operation geocode', t => {
   const params = formatParams({queries: {q: 'Lille', citycode: '57222', limit: 15}, operation: 'geocode'})
 
   t.deepEqual(params, {
@@ -32,7 +32,7 @@ test('Format parameters / operation geocode', t => {
   })
 })
 
-test('Format parameters / operation reverse', t => {
+test('formatParams / operation reverse', t => {
   const params = formatParams({queries: {lon: '3.045433', lat: '50.630992'}, operation: 'reverse'})
 
   t.deepEqual(params, {

--- a/test/search.js
+++ b/test/search.js
@@ -2,7 +2,7 @@
 
 import test from 'ava'
 
-import {ensureSingleValue, formatParams} from '../lib/search.js'
+import {ensureSingleValue, formatParams, createFeatureCollection} from '../lib/search.js'
 
 test('ensureSingleValue / with array', t => {
   const value = ['first', 'second', 'last']
@@ -41,4 +41,42 @@ test('formatParams / operation reverse', t => {
     limit: 5,
     lon: 3.045433
   })
+})
+
+test('createFeatureCollection / operation geocode', t => {
+  const features = [{id: 'foo'}, {id: 'bar'}]
+  const params = {q: 'Lille', limit: 2, filters: {}}
+  const result = createFeatureCollection({params, operation: 'geocode', results: features})
+
+  t.deepEqual(result, {
+    type: 'FeatureCollection',
+    version: 'draft',
+    features,
+    attribution: 'BAN',
+    licence: 'ETALAB-2.0',
+    query: 'Lille',
+    filters: undefined,
+    center: undefined,
+    limit: 2
+  })
+  t.is(Object.keys(result).length, 9)
+})
+
+test('createFeatureCollection / operation reverse', t => {
+  const features = [{id: 'foo'}, {id: 'bar'}]
+  const params = {q: 'Bordeaux', filters: {}}
+  const result = createFeatureCollection({params, operation: 'reverse', results: features})
+
+  t.deepEqual(result, {
+    type: 'FeatureCollection',
+    version: 'draft',
+    features,
+    attribution: 'BAN',
+    licence: 'ETALAB-2.0',
+    query: 'Bordeaux',
+    filters: undefined,
+    center: undefined,
+    limit: 1
+  })
+  t.is(Object.keys(result).length, 9)
 })

--- a/test/search.js
+++ b/test/search.js
@@ -1,6 +1,8 @@
+/* eslint-disable unicorn/numeric-separators-style */
+
 import test from 'ava'
 
-import {ensureSingleValue} from '../lib/search.js'
+import {ensureSingleValue, formatParams} from '../lib/search.js'
 
 test('ensure single value / with array', t => {
   const value = ['first', 'second', 'last']
@@ -15,3 +17,28 @@ test('ensure single value / with undefined', t => {
   t.is(ensureSingleValue(undefined), undefined)
 })
 
+test('Format parameters / operation geocode', t => {
+  const params = formatParams({queries: {q: 'Lille', citycode: '57222', limit: 15}, operation: 'geocode'})
+
+  t.deepEqual(params, {
+    autocomplete: true,
+    filters: {
+      citycode: '57222'
+    },
+    lat: undefined,
+    limit: 15,
+    lon: undefined,
+    q: 'Lille'
+  })
+})
+
+test('Format parameters / operation reverse', t => {
+  const params = formatParams({queries: {lon: '3.045433', lat: '50.630992'}, operation: 'reverse'})
+
+  t.deepEqual(params, {
+    filters: {},
+    lat: 50.630992,
+    limit: 5,
+    lon: 3.045433
+  })
+})


### PR DESCRIPTION
Add some tests :

- routes : 
  - `/search` and `/reverse` (1b8e302356f572267865ad5995e6e19fb7d73809 & b697b15b37acb7831f2fb6fce4d4a2677b4adc3e)

- functions in `lib/search` :
  - `ensureSignelValue` (ce511987fa8886ecb792bddce8926e9fa814d816)
  - `formatParams` (432afdb85a462575bd2ae2218bb0b415ef6aa22a)
  - `createFeatureCollection` (2d3687a32b376f4db81c51d46cd1b4f3d8ffe287)