### PR TITLE
Fix missing volume in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,14 +15,13 @@ services:
     volumes:
       - ./data/addok.conf:/etc/addok/addok.conf
       - ./data/addok.db:/data/addok.db
+      - ./data/dump.rdb:/data/dump.rdb
     networks:
       - addok-server-network
 
   addok-server-redis:
     image: etalab/addok-redis
     restart: always
-    volumes:
-      - ./data/dump.rdb:/data/dump.rdb
     networks:
       - addok-server-network
 


### PR DESCRIPTION
getting error:

```
addok-server-1        | file:///app/node_modules/addok-cluster/lib/redis.js:42
addok-server-1        |     throw new Error(`No Redis dump file found at ${dumpFilePath}`)
addok-server-1        |           ^
addok-server-1        |
addok-server-1        | Error: No Redis dump file found at /data/dump.rdb
addok-server-1        |     at startRedisServer (file:///app/node_modules/addok-cluster/lib/redis.js:42:11)
addok-server-1        |     at async createCluster (file:///app/node_modules/addok-cluster/lib/cluster.js:28:7)
addok-server-1        |     at async file:///app/server.js:16:17
```